### PR TITLE
Support matching by value

### DIFF
--- a/pkg/certinjectionwebhook/admission_controller.go
+++ b/pkg/certinjectionwebhook/admission_controller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -59,7 +60,6 @@ func NewAdmissionController(
 	caCertsData string,
 	imagePullSecrets corev1.LocalObjectReference,
 ) (*admissionController, error) {
-
 	if len(labels) == 0 && len(annotations) == 0 {
 		return nil, errors.New("at least one label or annotation required")
 	}
@@ -116,7 +116,7 @@ func (ac *admissionController) Admit(ctx context.Context, request *admissionv1.A
 		return &admissionv1.AdmissionResponse{Allowed: true}
 	}
 
-	if !(intersect(ac.labels, pod.Labels) || intersect(ac.annotations, pod.Annotations)) {
+	if !ac.matches(pod) {
 		logger.Info("does not contain matching labels or annotations, letting it through")
 		return &admissionv1.AdmissionResponse{Allowed: true}
 	}
@@ -250,10 +250,24 @@ func (ac *admissionController) setBuildServicePodDefaults(ctx context.Context, p
 
 var universalDeserializer = serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer()
 
-func intersect(a []string, b map[string]string) bool {
-	for _, k := range a {
-		if _, ok := b[k]; ok {
-			return true
+func (ac *admissionController) matches(pod corev1.Pod) bool {
+	return matchesMetadata(ac.labels, pod.Labels) || matchesMetadata(ac.annotations, pod.Annotations)
+}
+
+func matchesMetadata(matchers []string, metadata map[string]string) bool {
+	for _, matcher := range matchers {
+		key, value, hasValue := strings.Cut(matcher, "=")
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+
+		if hasValue {
+			if metadata[key] == value {
+				return true
+			}
+		} else {
+			if _, ok := metadata[key]; ok {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
This adds support for matching labels and annotations with specific values. For example, a label matcher of the format `app=kpack-controller` will only match a pod with the label `app` set to `kpack-controller`. This allows for more precise matching.

In the future we could consider allowing multiple, comma-separated values, for now having multiple entries for multiple values should do.