### PR TITLE
Add versioned resource annotations to configmaps

### DIFF
--- a/config/configmaps.yaml
+++ b/config/configmaps.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name:  ca-cert
   namespace: cert-injection-webhook
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   ca.crt: #@ base64.encode(data.values.ca_cert_data) if data.values.ca_cert_data else ""
 ---
@@ -14,6 +16,8 @@ kind: ConfigMap
 metadata:
   name:  http-proxy
   namespace: cert-injection-webhook
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   value: #@ data.values.http_proxy if data.values.http_proxy else ""
 ---
@@ -22,6 +26,8 @@ kind: ConfigMap
 metadata:
   name:  https-proxy
   namespace: cert-injection-webhook
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   value: #@ data.values.https_proxy if data.values.https_proxy else ""
 ---
@@ -30,5 +36,7 @@ kind: ConfigMap
 metadata:
   name:  no-proxy
   namespace: cert-injection-webhook
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   value: #@ data.values.no_proxy if data.values.no_proxy else ""


### PR DESCRIPTION
- This will cause kapp to restart the deployment when the configmap value changes

fixes #34