### PR TITLE
change setup-ca-certs builder to paketobuildpacks/builder-jammy-base

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,7 @@ jobs:
         pack_version: ${{ env.PACK_VERSION }}
         tag: ${{ env.PUBLIC_IMAGE_DEV_REPO }}/setup-ca-certs
         bp_go_targets: "./cmd/setup-ca-certs"
+        builder: "paketobuildpacks/builder-jammy-base"
 
   bundle:
     runs-on: ubuntu-latest


### PR DESCRIPTION
tiny run image does not have update-ca-certificates