### PR TITLE
Split certs up when passing in multiple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,10 +157,6 @@ jobs:
       run: |
         cat <<EOT > test-values.yaml
         ---
-        http_proxy: some-http-proxy
-        https_proxy: some-https-proxy
-        no_proxy: some-no-proxy
-        ca_cert_data: some-cert
         labels:
         - some-label-1
         - some-label-2

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -1,12 +1,22 @@
 package e2e
 
 import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"math/rand"
 	"os"
 	"os/user"
 	"path"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes"
@@ -14,11 +24,17 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	controllerNamespace = "cert-injection-webhook"
+	controllerName      = "cert-injection-webhook"
+)
+
 var (
 	clientSetup   sync.Once
 	k8sClient     *kubernetes.Clientset
 	clusterConfig *rest.Config
-	err           error
+	oldConfigs    map[string]string
+	rng           io.Reader
 )
 
 func getClient(t *testing.T) (kubernetes.Interface, error) {
@@ -28,12 +44,16 @@ func getClient(t *testing.T) (kubernetes.Interface, error) {
 
 		flag.Parse()
 
+		var err error
 		clusterConfig, err = clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 		require.NoError(t, err)
 
 		k8sClient, err = kubernetes.NewForConfig(clusterConfig)
 		require.NoError(t, err)
 	})
+
+	rng = rand.New(rand.NewSource(time.Now().UnixMilli()))
+	oldConfigs = make(map[string]string)
 
 	return k8sClient, nil
 }
@@ -46,4 +66,82 @@ func getKubeConfig() string {
 		return path.Join(usr.HomeDir, ".kube/config")
 	}
 	return ""
+}
+
+func generateCA() (*rsa.PrivateKey, *x509.Certificate, error) {
+	caKey, err := rsa.GenerateKey(rng, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// openssl only uses the first cert found for each common name, so we unique ones
+	// https://github.com/openssl/openssl/issues/16304
+	id := rand.Int()
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(int64(id)),
+		Subject: pkix.Name{
+			CommonName:   fmt.Sprintf("%d.sign", id),
+			Organization: []string{"signing"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	return caKey, caTemplate, nil
+}
+
+func encodeCert(pKey *rsa.PrivateKey, caCert *x509.Certificate) (string, error) {
+	bytes, err := x509.CreateCertificate(rng, caCert, caCert, &pKey.PublicKey, pKey)
+	if err != nil {
+		return "", err
+	}
+
+	encoded := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: bytes,
+	})
+	return string(encoded), nil
+}
+
+func generateAndUpdateCerts(ctx context.Context, client kubernetes.Interface) (*rsa.PrivateKey, *x509.Certificate, error) {
+	pKey, caCert, err := generateCA()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caEncoded, err := encodeCert(pKey, caCert)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = setCaCerts(ctx, client, caEncoded)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pKey, caCert, nil
+}
+
+func generateAndUpdateProxies(ctx context.Context, client kubernetes.Interface) (httpProxy string, httpsProxy string, noProxy string, err error) {
+	httpProxy = "some-http-proxy"
+	err = updateConfigmap(ctx, client, "http-proxy", "value", httpProxy)
+	if err != nil {
+		return
+	}
+
+	httpsProxy = "some-https-proxy"
+	err = updateConfigmap(ctx, client, "https-proxy", "value", httpsProxy)
+	if err != nil {
+		return
+	}
+
+	noProxy = "some-no-proxy"
+	err = updateConfigmap(ctx, client, "no-proxy", "value", noProxy)
+	if err != nil {
+		return
+	}
+	return
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -26,9 +24,18 @@ func TestCertInjectionWebhook(t *testing.T) {
 
 func testCertInjectionWebhook(t *testing.T, when spec.G, it spec.S) {
 	var (
-		client        kubernetes.Interface
-		ctx           = context.Background()
+		client kubernetes.Interface
+		ctx    = context.Background()
+
 		testNamespace = "test"
+		podName       string
+
+		waitForPodTermination = func() {
+			eventually(t, func() bool {
+				pod := getPod(t, ctx, client, testNamespace, podName)
+				return pod.Status.ContainerStatuses[0].State.Terminated != nil
+			}, 5*time.Second, 2*time.Minute)
+		}
 	)
 
 	it.Before(func() {
@@ -46,135 +53,163 @@ func testCertInjectionWebhook(t *testing.T, when spec.G, it spec.S) {
 		require.NoError(t, err)
 	})
 
-	when("injecting ca certificates and proxy env", func() {
+	when("ensuring containers ar injected", func() {
+		it.Before(func() {
+			_, _, err := generateAndUpdateCerts(ctx, client)
+			require.NoError(t, err)
+			require.NoError(t, restartController(t, ctx, client))
+		})
+
+		it.After(func() {
+			deletePod(t, ctx, client, testNamespace, podName)
+			require.NoError(t, restoreProxies(ctx, client))
+			require.NoError(t, restartController(t, ctx, client))
+		})
+
 		it("will match pods that have any label the webhook is matching on", func() {
-			//test expects webhook to match on some-label-1 and some-label-2
 			for i, label := range []string{"some-label-1", "some-label-2"} {
-				podName := fmt.Sprintf("testpod-label-%d", i)
+				podName = fmt.Sprintf("testpod-label-%d", i)
 				labels := map[string]string{label: ""}
 
-				createPod(t, ctx, client, testNamespace, podName, labels, map[string]string{})
+				createNoopPod(t, ctx, client, testNamespace, podName, labels, map[string]string{})
 				pod := getPod(t, ctx, client, testNamespace, podName)
-				assertCertInjection(t, pod)
-				assertProxyEnv(t, pod)
-				deletePod(t, ctx, client, testNamespace, podName)
+				require.True(t, hasInjectedContainer(t, pod), "should have cert injection container")
 			}
 		})
 
 		it("will match pods that have any annotation the webhook is matching on", func() {
-			//test expects webhook to match on some-annotation-1 and some-annotation-2
 			for i, annotation := range []string{"some-annotation-1", "some-annotation-2"} {
-				podName := fmt.Sprintf("testpod-annotation-%d", i)
+				podName = fmt.Sprintf("testpod-annotation-%d", i)
 				annotations := map[string]string{annotation: podName}
 
-				createPod(t, ctx, client, testNamespace, podName, map[string]string{}, annotations)
+				createNoopPod(t, ctx, client, testNamespace, podName, map[string]string{}, annotations)
 				pod := getPod(t, ctx, client, testNamespace, podName)
-				assertCertInjection(t, pod)
-				assertProxyEnv(t, pod)
-				deletePod(t, ctx, client, testNamespace, podName)
+				require.True(t, hasInjectedContainer(t, pod), "should have cert injection container")
 			}
+		})
+
+		it("doesn't match pods that don't have any annotation or label the webhook is matching on", func() {
+			podName = fmt.Sprintf("testpod-no-match")
+			labels := map[string]string{"some-label-3": ""}
+			annotations := map[string]string{"some-annotation-3": podName}
+
+			createNoopPod(t, ctx, client, testNamespace, podName, labels, annotations)
+			pod := getPod(t, ctx, client, testNamespace, podName)
+			require.False(t, hasInjectedContainer(t, pod), "should not have cert injection container")
+		})
+	})
+
+	when("ensuring injected containers are correct", func() {
+		it.After(func() {
+			deletePod(t, ctx, client, testNamespace, podName)
+			require.NoError(t, restoreProxies(ctx, client))
+			require.NoError(t, restoreCaCerts(ctx, client))
+			require.NoError(t, restartController(t, ctx, client))
+		})
+
+		podLogFormat := `setup-ca-cert container logs:
+%s
+test container logs:
+%s`
+
+		it("injects proxy envs", func() {
+			http, https, no, err := generateAndUpdateProxies(ctx, client)
+			require.NoError(t, err)
+
+			require.NoError(t, restartController(t, ctx, client))
+
+			podName = "testpod-proxy-envs"
+			createNoopPod(t, ctx, client, testNamespace, podName, map[string]string{"some-label-1": ""}, map[string]string{})
+			pod := getPod(t, ctx, client, testNamespace, podName)
+			expectedEnv := []corev1.EnvVar{
+				{Name: "HTTP_PROXY", Value: http},
+				{Name: "http_proxy", Value: http},
+				{Name: "HTTPS_PROXY", Value: https},
+				{Name: "https_proxy", Value: https},
+				{Name: "NO_PROXY", Value: no},
+				{Name: "no_proxy", Value: no},
+			}
+			actualEnv := pod.Spec.Containers[0].Env
+			assert.Equal(t, expectedEnv, actualEnv)
+		})
+
+		it("injects certs", func() {
+			caKey, caCert, err := generateAndUpdateCerts(ctx, client)
+			require.NoError(t, err)
+
+			require.NoError(t, restartController(t, ctx, client))
+
+			testingCert, err := generateCert(caKey, caCert)
+			require.NoError(t, err)
+
+			podName = "testpod-verify-cert"
+			createCertTestPod(t, ctx, client,
+				testNamespace, podName,
+				testingCert,
+			)
+
+			waitForPodTermination()
+			pod := getPod(t, ctx, client, testNamespace, podName)
+			require.Len(t, pod.Status.ContainerStatuses, 1)
+
+			setupLogs := getLogs(t, ctx, client, testNamespace, pod.Name, "setup-ca-certs")
+			podLogs := getLogs(t, ctx, client, testNamespace, pod.Name, "test")
+			require.Equal(t, int32(0), pod.Status.ContainerStatuses[0].State.Terminated.ExitCode,
+				podLogFormat, setupLogs, podLogs,
+			)
+		})
+
+		it("can handle super long certs", func() {
+			key1, cert1, err := generateCA()
+			require.NoError(t, err)
+			pem1, err := encodeCert(key1, cert1)
+			require.NoError(t, err)
+
+			key2, cert2, err := generateCA()
+			require.NoError(t, err)
+			pem2, err := encodeCert(key2, cert2)
+			require.NoError(t, err)
+
+			// k8s configmaps have a size limit of 1mb, 550 certs should be just shy of that
+			certChain := ""
+			for i := 0; i < 549; i++ {
+				certChain += fmt.Sprintln(pem1)
+			}
+			certChain += fmt.Sprintln(pem2)
+			require.NoError(t, setCaCerts(ctx, client, certChain))
+
+			require.NoError(t, restartController(t, ctx, client))
+
+			testingCert, err := generateCert(key2, cert2)
+			require.NoError(t, err)
+
+			podName = "testpod-many-certs"
+			createCertTestPod(t, ctx, client,
+				testNamespace, podName,
+				testingCert,
+			)
+
+			waitForPodTermination()
+			pod := getPod(t, ctx, client, testNamespace, podName)
+			require.Len(t, pod.Status.ContainerStatuses, 1)
+
+			setupLogs := getLogs(t, ctx, client, testNamespace, pod.Name, "setup-ca-certs")
+			podLogs := getLogs(t, ctx, client, testNamespace, pod.Name, "test")
+			require.Equal(t, int32(0), pod.Status.ContainerStatuses[0].State.Terminated.ExitCode,
+				podLogFormat, setupLogs, podLogs,
+			)
 		})
 	})
 }
 
-func deletePod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string) {
-	err := client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
-	if err != nil {
-		t.Log(err)
-	}
-}
-
-func createPod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string, labels map[string]string, annotations map[string]string) {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:       "nginx",
-					Image:      "nginx:latest",
-					Command:    nil,
-					Args:       nil,
-					WorkingDir: "",
-					Ports: []corev1.ContainerPort{
-						{
-							ContainerPort: 80,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	_, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
-	require.NoError(t, err)
-}
-
-func deleteNamespace(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace string) {
-	err := client.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-	require.True(t, err == nil || k8serrors.IsNotFound(err))
-	if k8serrors.IsNotFound(err) {
-		return
-	}
-
-	var (
-		timeout int64 = 120
-		closed        = false
-	)
-
-	watcher, err := client.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{
-		TimeoutSeconds: &timeout,
-	})
-	require.NoError(t, err)
-
-	for evt := range watcher.ResultChan() {
-		if evt.Type != watch.Deleted {
-			continue
-		}
-		if ns, ok := evt.Object.(*corev1.Namespace); ok {
-			if ns.Name == namespace {
-				closed = true
-				break
-			}
-		}
-	}
-	require.True(t, closed)
-}
-
-func getPod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string) *corev1.Pod {
-	var (
-		pod *corev1.Pod
-		err error
-	)
-	eventually(t, func() bool {
-		pod, err = client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if k8serrors.IsNotFound(err) {
-			return false
-		} else if err != nil {
-			t.Error(err)
-			return false
-		}
-
-		return true
-	}, 5*time.Second, 2*time.Minute)
-
-	return pod
-}
-
-func assertCertInjection(t *testing.T, pod *corev1.Pod) {
+func hasInjectedContainer(t *testing.T, pod *corev1.Pod) bool {
 	var (
 		initContainerPresent bool
 		volumePresent        bool
 	)
 
 	for _, container := range pod.Spec.InitContainers {
-		if container.Name == "setup-ca-certs" &&
-			container.VolumeMounts[0].Name == "ca-certs" &&
-			container.Env[0].Value == "some-cert" {
+		if container.Name == "setup-ca-certs" && container.VolumeMounts[0].Name == "ca-certs" {
 			initContainerPresent = true
 			break
 		}
@@ -187,40 +222,5 @@ func assertCertInjection(t *testing.T, pod *corev1.Pod) {
 		}
 	}
 
-	injected := initContainerPresent && volumePresent
-	if !injected {
-		t.Errorf("pod should have cert injection: %v", pod)
-	}
-}
-
-func assertProxyEnv(t *testing.T, pod *corev1.Pod) {
-	expectedEnv := []corev1.EnvVar{
-		{
-			Name:  "HTTP_PROXY",
-			Value: "some-http-proxy",
-		},
-		{
-			Name:  "http_proxy",
-			Value: "some-http-proxy",
-		},
-		{
-			Name:  "HTTPS_PROXY",
-			Value: "some-https-proxy",
-		},
-		{
-			Name:  "https_proxy",
-			Value: "some-https-proxy",
-		},
-		{
-			Name:  "NO_PROXY",
-			Value: "some-no-proxy",
-		},
-		{
-			Name:  "no_proxy",
-			Value: "some-no-proxy",
-		},
-	}
-
-	actualEnv := pod.Spec.Containers[0].Env
-	assert.Equal(t, expectedEnv, actualEnv)
+	return initContainerPresent && volumePresent
 }

--- a/e2e/testhelpers.go
+++ b/e2e/testhelpers.go
@@ -45,9 +45,9 @@ cat > test.crt <<EOF
 EOF
 
 # openssl has its own separate certs dir ('openssl version -a' -> OPENSSLDIR),
-# this is usually updated by 'update-ca-certificates', but since we only save the /etc/ssl/certs
-# dir, we need to explicitly configure it here
-openssl verify -CAfile /etc/ssl/certs/ca-certificates.crt test.crt
+# this is usually updated by 'update-ca-certificates', but since we only save
+# the /etc/ssl/certs dir, we need to explicitly pass it in here
+openssl verify -CApath /etc/ssl/certs/ test.crt
 `, cert)
 }
 

--- a/e2e/testhelpers.go
+++ b/e2e/testhelpers.go
@@ -1,8 +1,25 @@
 package e2e
 
 import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 func eventually(t *testing.T, fun func() bool, interval time.Duration, duration time.Duration) {
@@ -18,4 +35,269 @@ func eventually(t *testing.T, fun func() bool, interval time.Duration, duration 
 			return
 		}
 	}
+}
+func opensslTestScriptFor(cert string) string {
+	return fmt.Sprintf(`
+cd $HOME
+
+cat > test.crt <<EOF
+%s
+EOF
+
+# openssl has its own separate certs dir ('openssl version -a' -> OPENSSLDIR),
+# this is usually updated by 'update-ca-certificates', but since we only save the /etc/ssl/certs
+# dir, we need to explicitly configure it here
+openssl verify -CAfile /etc/ssl/certs/ca-certificates.crt test.crt
+`, cert)
+}
+
+func deletePod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string) {
+	err := client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Log(err)
+	}
+}
+
+func createCertTestPod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string, verificationCert string) {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"some-label-1": ""},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:       "test",
+					Image:      "paketobuildpacks/build-jammy-base",
+					Command:    []string{"bash"},
+					Args:       []string{"-c", opensslTestScriptFor(verificationCert)},
+					WorkingDir: "",
+				},
+			},
+		},
+	}
+
+	_, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func createNoopPod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string, labels map[string]string, annotations map[string]string) {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:       "test",
+					Image:      "nginx:latest",
+					Command:    nil,
+					Args:       nil,
+					WorkingDir: "",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func getLogs(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name, container string) string {
+	t.Helper()
+	req := client.CoreV1().Pods(namespace).GetLogs(name, &corev1.PodLogOptions{Container: container})
+	logReader, err := req.Stream(ctx)
+	require.NoError(t, err)
+	defer logReader.Close()
+
+	b, err := io.ReadAll(logReader)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func deleteNamespace(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace string) {
+	t.Helper()
+
+	err := client.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
+	require.True(t, err == nil || k8serrors.IsNotFound(err))
+	if k8serrors.IsNotFound(err) {
+		return
+	}
+
+	var (
+		timeout int64 = 120
+		closed        = false
+	)
+
+	watcher, err := client.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{
+		TimeoutSeconds: &timeout,
+	})
+	require.NoError(t, err)
+
+	for evt := range watcher.ResultChan() {
+		if evt.Type != watch.Deleted {
+			continue
+		}
+		if ns, ok := evt.Object.(*corev1.Namespace); ok {
+			if ns.Name == namespace {
+				closed = true
+				break
+			}
+		}
+	}
+	require.True(t, closed)
+}
+
+func getPod(t *testing.T, ctx context.Context, client kubernetes.Interface, namespace, name string) *corev1.Pod {
+	t.Helper()
+
+	var (
+		pod *corev1.Pod
+		err error
+	)
+	eventually(t, func() bool {
+		pod, err = client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return false
+		} else if err != nil {
+			t.Error(err)
+			return false
+		}
+
+		return true
+	}, 5*time.Second, 2*time.Minute)
+
+	return pod
+}
+
+func parseConfigmapName(ctx context.Context, client kubernetes.Interface, name string) (string, error) {
+	deployment, err := client.AppsV1().Deployments(controllerNamespace).Get(ctx, controllerName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	configmapName := ""
+	for _, v := range deployment.Spec.Template.Spec.Volumes {
+		if v.Name == name {
+			configmapName = v.ConfigMap.Name
+			break
+		}
+	}
+
+	if configmapName == "" {
+		return "", fmt.Errorf("no configmap found")
+	}
+	return configmapName, nil
+}
+
+func updateConfigmap(ctx context.Context, client kubernetes.Interface, name, key, value string) error {
+	configmapName, err := parseConfigmapName(ctx, client, name)
+	if err != nil {
+		return err
+	}
+
+	config, err := client.CoreV1().ConfigMaps(controllerNamespace).Get(ctx, configmapName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	oldConfigs[name] = config.Data[key]
+
+	newConfig := config.DeepCopy()
+	newConfig.Data[key] = value
+
+	_, err = client.CoreV1().ConfigMaps(controllerNamespace).Update(ctx, newConfig, metav1.UpdateOptions{})
+	return err
+}
+
+func setCaCerts(ctx context.Context, client kubernetes.Interface, certs string) error {
+	encoded := &strings.Builder{}
+	_, err := io.WriteString(base64.NewEncoder(base64.StdEncoding, encoded), certs)
+	if err != nil {
+		return err
+	}
+
+	return updateConfigmap(ctx, client, "webhook-ca-cert", "ca.crt", encoded.String())
+}
+
+func restoreCaCerts(ctx context.Context, client kubernetes.Interface) error {
+	return updateConfigmap(ctx, client, "webhook-ca-cert", "ca.crt", oldConfigs["ca-cert"])
+}
+
+func restoreProxies(ctx context.Context, client kubernetes.Interface) error {
+	err := updateConfigmap(ctx, client, "http-proxy", "value", oldConfigs["http-proxy"])
+	if err != nil {
+		return err
+	}
+	err = updateConfigmap(ctx, client, "https-proxy", "value", oldConfigs["https-proxy"])
+	if err != nil {
+		return err
+	}
+
+	err = updateConfigmap(ctx, client, "no-proxy", "value", oldConfigs["no-proxy"])
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func restartController(t *testing.T, ctx context.Context, client kubernetes.Interface) error {
+	err := client.CoreV1().Pods(controllerNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+		LabelSelector: "app=cert-injection-webhook",
+	})
+	require.NoError(t, err)
+
+	eventually(t, func() bool {
+		list, err := client.CoreV1().Pods(controllerNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=cert-injection-webhook",
+		})
+		require.NoError(t, err)
+
+		return len(list.Items) == 1
+	}, 5*time.Second, 2*time.Minute)
+
+	return nil
+}
+
+func generateCert(caPrivateKey *rsa.PrivateKey, caCert *x509.Certificate) (string, error) {
+	privateKey, err := rsa.GenerateKey(rng, 2048)
+	if err != nil {
+		return "", err
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName:   "test",
+			Organization: []string{"testing"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(10, 0, 0),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+	certBytes, err := x509.CreateCertificate(rng, cert, caCert, &privateKey.PublicKey, caPrivateKey)
+	if err != nil {
+		return "", err
+	}
+
+	encoded := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	return string(encoded), nil
 }

--- a/pkg/certinjectionwebhook/admission_controller.go
+++ b/pkg/certinjectionwebhook/admission_controller.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/cert-injection-webhook/pkg/certs"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +20,8 @@ import (
 	"knative.dev/pkg/apis/duck"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/webhook"
+
+	"github.com/vmware-tanzu/cert-injection-webhook/pkg/certs"
 )
 
 const (

--- a/pkg/certinjectionwebhook/admission_controller_test.go
+++ b/pkg/certinjectionwebhook/admission_controller_test.go
@@ -81,7 +81,7 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
 			annotation = "some.annotation"
 
 			setupCACertsImage = "some-ca-certs-image"
-			caCertsData       = "some-ca-certs-data"
+			caCertsData       = "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"
 		)
 
 		envVars := []corev1.EnvVar{
@@ -462,8 +462,8 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
     "path": "/spec/initContainers/0/env",
     "value": [
       {
-        "name": "CA_CERTS_DATA",
-        "value": "some-ca-certs-data"
+        "name": "CA_CERTS_DATA_0",
+        "value": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
       }
     ]
   },
@@ -676,8 +676,8 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
     "path": "/spec/initContainers/0/env",
     "value": [
       {
-        "name": "CA_CERTS_DATA",
-        "value": "some-ca-certs-data"
+        "name": "CA_CERTS_DATA_0",
+        "value": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
       }
     ]
   },
@@ -857,8 +857,8 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
     "path": "/spec/initContainers/0/env",
     "value": [
       {
-        "name": "CA_CERTS_DATA",
-        "value": "some-ca-certs-data"
+        "name": "CA_CERTS_DATA_0",
+        "value": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
       }
     ]
   },
@@ -1111,8 +1111,8 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
     "path": "/spec/initContainers/0/env",
     "value": [
       {
-        "name": "CA_CERTS_DATA",
-        "value": "some-ca-certs-data"
+        "name": "CA_CERTS_DATA_0",
+        "value": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
       }
     ]
   },
@@ -1328,7 +1328,7 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
 			err = json.Unmarshal(response.Patch, &actualPatch)
 			require.NoError(t, err)
 
-			expectedJSON := "[{\"op\":\"add\",\"path\":\"/spec/volumes\",\"value\":[{\"emptyDir\":{},\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/imagePullSecrets\",\"value\":[{\"name\":\"system-registry-credentials\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/2\",\"value\":{\"env\":[{\"name\":\"EXISTING\",\"value\":\"VALUE\"}],\"image\":\"image\",\"name\":\"init-container-with-env\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/env\",\"value\":[{\"name\":\"CA_CERTS_DATA\",\"value\":\"some-ca-certs-data\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/workspace\",\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/imagePullPolicy\",\"value\":\"IfNotPresent\"},{\"op\": \"add\", \"path\": \"/spec/initContainers/0/securityContext\", \"value\": {\"allowPrivilegeEscalation\": false, \"capabilities\": {\"drop\": [\"ALL\"]}, \"privileged\": false, \"runAsNonRoot\": true, \"seccompProfile\": {\"type\": \"RuntimeDefault\"}}},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/name\",\"value\":\"setup-ca-certs\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/image\",\"value\":\"some-ca-certs-image\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/workingDir\",\"value\":\"/workspace\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/1/name\",\"value\":\"init-container-without-env\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"remove\",\"path\":\"/spec/initContainers/1/env\"},{\"op\":\"add\",\"path\":\"/spec/containers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"add\",\"path\":\"/spec/containers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}]"
+			expectedJSON := "[{\"op\":\"add\",\"path\":\"/spec/volumes\",\"value\":[{\"emptyDir\":{},\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/imagePullSecrets\",\"value\":[{\"name\":\"system-registry-credentials\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/2\",\"value\":{\"env\":[{\"name\":\"EXISTING\",\"value\":\"VALUE\"}],\"image\":\"image\",\"name\":\"init-container-with-env\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/env\",\"value\":[{\"name\":\"CA_CERTS_DATA_0\",\"value\":\"-----BEGIN CERTIFICATE-----\\n-----END CERTIFICATE-----\\n\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/workspace\",\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/imagePullPolicy\",\"value\":\"IfNotPresent\"},{\"op\": \"add\", \"path\": \"/spec/initContainers/0/securityContext\", \"value\": {\"allowPrivilegeEscalation\": false, \"capabilities\": {\"drop\": [\"ALL\"]}, \"privileged\": false, \"runAsNonRoot\": true, \"seccompProfile\": {\"type\": \"RuntimeDefault\"}}},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/name\",\"value\":\"setup-ca-certs\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/image\",\"value\":\"some-ca-certs-image\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/workingDir\",\"value\":\"/workspace\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/1/name\",\"value\":\"init-container-without-env\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"remove\",\"path\":\"/spec/initContainers/1/env\"},{\"op\":\"add\",\"path\":\"/spec/containers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"add\",\"path\":\"/spec/containers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}]"
 			var expectedPatch []jsonpatch.JsonPatchOperation
 			err = json.Unmarshal([]byte(expectedJSON), &expectedPatch)
 			require.NoError(t, err)
@@ -1378,7 +1378,7 @@ func testPodAdmissionController(t *testing.T, when spec.G, it spec.S) {
 			err = json.Unmarshal(response.Patch, &actualPatch)
 			require.NoError(t, err)
 
-			expectedJSON := "[{\"op\":\"add\",\"path\":\"/spec/volumes\",\"value\":[{\"emptyDir\":{},\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/imagePullSecrets/1\",\"value\":{\"name\":\"system-registry-credentials\"}},{\"op\":\"add\",\"path\":\"/spec/initContainers/2\",\"value\":{\"env\":[{\"name\":\"EXISTING\",\"value\":\"VALUE\"}],\"image\":\"image\",\"name\":\"init-container-with-env\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/env\",\"value\":[{\"name\":\"CA_CERTS_DATA\",\"value\":\"some-ca-certs-data\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/workspace\",\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/imagePullPolicy\",\"value\":\"IfNotPresent\"},{\"op\": \"add\", \"path\": \"/spec/initContainers/0/securityContext\", \"value\": {\"allowPrivilegeEscalation\": false, \"capabilities\": {\"drop\": [\"ALL\"]}, \"privileged\": false, \"runAsNonRoot\": true, \"seccompProfile\": {\"type\": \"RuntimeDefault\"}}},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/name\",\"value\":\"setup-ca-certs\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/image\",\"value\":\"some-ca-certs-image\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/workingDir\",\"value\":\"/workspace\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/1/name\",\"value\":\"init-container-without-env\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"remove\",\"path\":\"/spec/initContainers/1/env\"},{\"op\":\"add\",\"path\":\"/spec/containers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"add\",\"path\":\"/spec/containers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}]"
+			expectedJSON := "[{\"op\":\"add\",\"path\":\"/spec/volumes\",\"value\":[{\"emptyDir\":{},\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/imagePullSecrets/1\",\"value\":{\"name\":\"system-registry-credentials\"}},{\"op\":\"add\",\"path\":\"/spec/initContainers/2\",\"value\":{\"env\":[{\"name\":\"EXISTING\",\"value\":\"VALUE\"}],\"image\":\"image\",\"name\":\"init-container-with-env\",\"resources\":{},\"volumeMounts\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/env\",\"value\":[{\"name\":\"CA_CERTS_DATA_0\",\"value\":\"-----BEGIN CERTIFICATE-----\\n-----END CERTIFICATE-----\\n\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/workspace\",\"name\":\"ca-certs\"}]},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/imagePullPolicy\",\"value\":\"IfNotPresent\"},{\"op\": \"add\", \"path\": \"/spec/initContainers/0/securityContext\", \"value\": {\"allowPrivilegeEscalation\": false, \"capabilities\": {\"drop\": [\"ALL\"]}, \"privileged\": false, \"runAsNonRoot\": true, \"seccompProfile\": {\"type\": \"RuntimeDefault\"}}},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/name\",\"value\":\"setup-ca-certs\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/0/image\",\"value\":\"some-ca-certs-image\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/0/workingDir\",\"value\":\"/workspace\"},{\"op\":\"replace\",\"path\":\"/spec/initContainers/1/name\",\"value\":\"init-container-without-env\"},{\"op\":\"add\",\"path\":\"/spec/initContainers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"remove\",\"path\":\"/spec/initContainers/1/env\"},{\"op\":\"add\",\"path\":\"/spec/containers/0/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]},{\"op\":\"add\",\"path\":\"/spec/containers/1/volumeMounts\",\"value\":[{\"mountPath\":\"/etc/ssl/certs\",\"name\":\"ca-certs\",\"readOnly\":true}]}]"
 			var expectedPatch []jsonpatch.JsonPatchOperation
 			err = json.Unmarshal([]byte(expectedJSON), &expectedPatch)
 			require.NoError(t, err)

--- a/pkg/certs/cert.go
+++ b/pkg/certs/cert.go
@@ -1,0 +1,43 @@
+package certs
+
+import (
+	"encoding/pem"
+	"fmt"
+	"strings"
+)
+
+// Split a single string of multiple certs into multiple strings of single
+// certs.
+func Split(certs string) []string {
+	var res []string
+	for block, data := pem.Decode([]byte(certs)); block != nil; block, data = pem.Decode(data) {
+		res = append(res, string(pem.EncodeToMemory(block)))
+	}
+	return res
+}
+
+// Parse the environment variables satsifying the pattern and construct a list
+// of certs.
+func Parse(pattern string, environ []string) (string, int, error) {
+	envVars := map[string]string{}
+	for _, e := range environ {
+		parts := strings.SplitN(e, "=", 2)
+		envVars[parts[0]] = parts[1]
+	}
+
+	var certs string
+	for i := 0; ; i++ {
+		name := fmt.Sprintf("%s_%d", pattern, i)
+		fragment, found := envVars[name]
+		if !found {
+			return certs, i, nil
+		}
+
+		block, _ := pem.Decode([]byte(fragment))
+		if block == nil {
+			return "", i, fmt.Errorf("cert not in pem format")
+		}
+
+		certs += fragment
+	}
+}

--- a/pkg/certs/cert.go
+++ b/pkg/certs/cert.go
@@ -18,26 +18,26 @@ func Split(certs string) []string {
 
 // Parse the environment variables satsifying the pattern and construct a list
 // of certs.
-func Parse(pattern string, environ []string) (string, int, error) {
+func Parse(pattern string, environ []string) ([]string, error) {
 	envVars := map[string]string{}
 	for _, e := range environ {
 		parts := strings.SplitN(e, "=", 2)
 		envVars[parts[0]] = parts[1]
 	}
 
-	var certs string
+	var certs []string
 	for i := 0; ; i++ {
 		name := fmt.Sprintf("%s_%d", pattern, i)
 		fragment, found := envVars[name]
 		if !found {
-			return certs, i, nil
+			return certs, nil
 		}
 
 		block, _ := pem.Decode([]byte(fragment))
 		if block == nil {
-			return "", i, fmt.Errorf("cert not in pem format")
+			return nil, fmt.Errorf("cert not in pem format")
 		}
 
-		certs += fragment
+		certs = append(certs, fragment)
 	}
 }

--- a/pkg/certs/cert_test.go
+++ b/pkg/certs/cert_test.go
@@ -98,9 +98,9 @@ func testCerts(t *testing.T, when spec.G, it spec.S) {
 				"SOME-OTHER=ENV",
 			}
 
-			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			certs, err := certs.Parse("CA_CERT_DATA", envs)
 			require.NoError(t, err)
-			require.Equal(t, "", cert)
+			require.Len(t, certs, 0)
 		})
 
 		it("parsing single valid cert", func() {
@@ -109,9 +109,10 @@ func testCerts(t *testing.T, when spec.G, it spec.S) {
 				fmt.Sprintf("CA_CERT_DATA_0=%v", c1),
 			}
 
-			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			certs, err := certs.Parse("CA_CERT_DATA", envs)
 			require.NoError(t, err)
-			require.Equal(t, c1, cert)
+			require.Len(t, certs, 1)
+			require.Equal(t, c1, certs[0])
 		})
 
 		it("parsing single invalid cert", func() {
@@ -133,9 +134,10 @@ func testCerts(t *testing.T, when spec.G, it spec.S) {
 				fmt.Sprintf("CA_CERT_DATA_2=%v", c3),
 			}
 
-			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			certs, err := certs.Parse("CA_CERT_DATA", envs)
 			require.NoError(t, err)
-			require.Equal(t, c1+"\n"+c2+"\n"+c3, cert)
+			require.Len(t, certs, 3)
+			require.Equal(t, []string{c1, c2, c3}, certs)
 		})
 
 		it("parsing multiple invalid certs", func() {

--- a/pkg/certs/cert_test.go
+++ b/pkg/certs/cert_test.go
@@ -1,0 +1,154 @@
+package certs_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/cert-injection-webhook/pkg/certs"
+)
+
+func TestCerts(t *testing.T) {
+	spec.Run(t, "Certs", testCerts)
+}
+
+func makeCaCert(t *testing.T, rng io.Reader) string {
+	t.Helper()
+	pKey, err := ecdsa.GenerateKey(elliptic.P256(), rng)
+	require.NoError(t, err)
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization:  []string{""},
+			Country:       []string{"US"},
+			Province:      []string{""},
+			Locality:      []string{""},
+			StreetAddress: []string{""},
+			PostalCode:    []string{""},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	ca, err := x509.CreateCertificate(rng, cert, cert, &pKey.PublicKey, pKey)
+	require.NoError(t, err)
+
+	pem := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: ca,
+	})
+	return string(pem)
+}
+
+func testCerts(t *testing.T, when spec.G, it spec.S) {
+	// use insecure prng for certs since this is just a test
+	source := rand.NewSource(time.Now().UnixNano())
+	prng := rand.New(source)
+
+	when("Splitting", func() {
+		it("splits single cert", func() {
+			c1 := makeCaCert(t, prng)
+
+			c := certs.Split(c1)
+			require.Len(t, c, 1)
+			require.Equal(t, c1, c[0])
+		})
+
+		it("splits multiple certs", func() {
+			c1 := makeCaCert(t, prng)
+			c2 := makeCaCert(t, prng)
+			c3 := makeCaCert(t, prng)
+
+			c := certs.Split(c1 + "\n" + c2 + "\n" + c3)
+			require.Len(t, c, 3)
+			require.Equal(t, c1, c[0])
+			require.Equal(t, c2, c[1])
+			require.Equal(t, c3, c[2])
+		})
+
+		it("ignores invalid certs", func() {
+			c1 := makeCaCert(t, prng)
+			c3 := makeCaCert(t, prng)
+
+			c := certs.Split(c1 + "\n" + "not-a-cert" + "\n" + c3)
+			require.Len(t, c, 2)
+			require.Equal(t, c1, c[0])
+			require.Equal(t, c3, c[1])
+		})
+	})
+
+	when("Parsing", func() {
+		it("parsing no cert", func() {
+			envs := []string{
+				"SOME-OTHER=ENV",
+			}
+
+			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			require.NoError(t, err)
+			require.Equal(t, "", cert)
+		})
+
+		it("parsing single valid cert", func() {
+			c1 := makeCaCert(t, prng)
+			envs := []string{
+				fmt.Sprintf("CA_CERT_DATA_0=%v", c1),
+			}
+
+			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			require.NoError(t, err)
+			require.Equal(t, c1, cert)
+		})
+
+		it("parsing single invalid cert", func() {
+			envs := []string{
+				"CA_CERT_DATA_0=not-a-cert",
+			}
+
+			_, err := certs.Parse("CA_CERT_DATA", envs)
+			require.Error(t, err)
+		})
+
+		it("parsing multiple certs", func() {
+			c1 := makeCaCert(t, prng)
+			c2 := makeCaCert(t, prng)
+			c3 := makeCaCert(t, prng)
+			envs := []string{
+				fmt.Sprintf("CA_CERT_DATA_0=%v", c1),
+				fmt.Sprintf("CA_CERT_DATA_1=%v", c2),
+				fmt.Sprintf("CA_CERT_DATA_2=%v", c3),
+			}
+
+			cert, err := certs.Parse("CA_CERT_DATA", envs)
+			require.NoError(t, err)
+			require.Equal(t, c1+"\n"+c2+"\n"+c3, cert)
+		})
+
+		it("parsing multiple invalid certs", func() {
+			c1 := makeCaCert(t, prng)
+			c3 := makeCaCert(t, prng)
+			envs := []string{
+				fmt.Sprintf("CA_CERT_DATA_0=%v", c1),
+				fmt.Sprintf("CA_CERT_DATA_1=not-a-cert"),
+				fmt.Sprintf("CA_CERT_DATA_2=%v", c3),
+			}
+
+			_, err := certs.Parse("CA_CERT_DATA", envs)
+			require.Error(t, err)
+		})
+	})
+}


### PR DESCRIPTION
- When generating the sidecar container, the reconciler will pass in certs as multiple single env vars instead of a single large string.
    This resolves a bug that occurs if the list is too large to be passed in
- When the sidecar container writes the certs to file, it will also write them to individual files instead of a concatenated file
    This is mainly for playing nice with `update-ca-certificates` and `openssl rehash`, it should have no impact outside of that
- Add tools to e2e test to reconfigure and redeploy the controller during the tests