### PR TITLE
Revert "Bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -238,7 +238,7 @@ jobs:
         done
 
     - name: Upload image refs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: final-image-refs
         path: final-image-refs/*
@@ -256,7 +256,7 @@ jobs:
         tar -C imgpkg-bundle -cvzf config.tar.gz config
 
     - name: Upload bundle
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: config
         path: config.tar.gz


### PR DESCRIPTION
Reverts vmware-tanzu/cert-injection-webhook#93

This PR didn't bump the `.github/actions/*`, and it's a non-trivial change to make it work again