### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
         only: ytt, kapp, imgpkg, kbld
 
     - name: Download bundle lock
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: pre-release-bundle.lock
 
@@ -201,7 +201,7 @@ jobs:
         only: ytt, kbld, imgpkg
 
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
 
     - name: Docker Login
       uses: ./.github/actions/docker-login


### PR DESCRIPTION
Reverts vmware-tanzu/cert-injection-webhook#92

This requires non-trivial changes in `.github/actions/*`