### PR TITLE
Force sync hashed symlinks for ca-bundle for multiple certificates

### DIFF
--- a/cmd/setup-ca-certs/main.go
+++ b/cmd/setup-ca-certs/main.go
@@ -50,6 +50,13 @@ func main() {
 	}
 	logger.Println(string(out))
 
+	logger.Println("Forcing the generation of hashed symlinks...")
+	cmd = exec.Command("c_rehash", tempCerts)
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	logger.Println("Copying CA certificates...")
 	err = CopyDir(tempCerts, "/workspace")
 	if err != nil {


### PR DESCRIPTION
Related to issue https://github.com/vmware-tanzu/cert-injection-webhook/issues/119

update-ca-certificate refuse to generate hashed symlinks when two certificate is part of the same file. To fix this issue, we want to run c_rehash to force the generation of hashed symlinks.